### PR TITLE
add flag for limiting information

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -43,6 +43,6 @@ func newListCmd(commandLineOptions *options.CommandLineOption) *cobra.Command {
 
 		},
 	}
-
+	listCmd.Flags().BoolVarP(&commandLineOptions.LimitInfo, "limitInfo", "i", false, "specifies if call is made from topology or not")
 	return listCmd
 }

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -21,9 +21,7 @@ func NewListAction(commandLineOptions *options.CommandLineOption) *ListAction {
 }
 
 func (l *ListAction) Run() error {
-
-	releases, err := l.helmChartClient.ListReleases()
-
+	releases, err := l.helmChartClient.ListReleases(l.commandLineOptions.LimitInfo)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/helm.go
+++ b/pkg/client/helm.go
@@ -287,9 +287,8 @@ func (c *HelmChartClient) GetIndex() (*repo.IndexFile, error) {
 
 }
 
-func (c *HelmChartClient) ListReleases() (*[]release.Release, error) {
-
-	req, err := c.newRequest("GET", fmt.Sprintf("/api/helm/releases?ns=%s", c.namespace), nil)
+func (c *HelmChartClient) ListReleases(limitInfo bool) (*[]release.Release, error) {
+	req, err := c.newRequest("GET", fmt.Sprintf("/api/helm/releases?ns=%s&limitInfo=%s", c.namespace, limitInfo), nil)
 
 	if err != nil {
 		return nil, err

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -26,6 +26,7 @@ type CommandLineOption struct {
 	VerifierOptions []string
 	FileValues      []string
 	Install         bool
+	LimitInfo       bool
 }
 
 func NewCommandLineOption() *CommandLineOption {


### PR DESCRIPTION
This PR modifies the response to be returned for list releases endpoint. The PR is aimed at improving the performance of list releases api . If the call is made from list releases page we can return limited information else the entire manifests and notes will be returned too
Signed-off-by: Kartikey Mamgain [mamgainkartikey@gmail.com]